### PR TITLE
Add syntax highlighting to code blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ It's compatible with any rack-based framework, such as Rails or Sinatra.
 
 Add this line to your application's Gemfile:
 
-    gem 'poncho'
+```ruby
+gem 'poncho'
+```
 
 And then execute:
 
@@ -22,30 +24,32 @@ Or install it yourself as:
 
 ## TLDR Usage
 
-    class ChargeResource < Poncho::Resource
-      param :amount, :type => :integer
-      param :currency
+```ruby
+class ChargeResource < Poncho::Resource
+  param :amount, :type => :integer
+  param :currency
 
-      def currency
-        super || 'USD'
-      end
-    end
+  def currency
+    super || 'USD'
+  end
+end
 
-    class ChargeCreateMethod < Poncho::JSONMethod
-      param :amount, :type => :integer, :required => true
-      param :currency, :in => ['USD', 'GBP']
+class ChargeCreateMethod < Poncho::JSONMethod
+  param :amount, :type => :integer, :required => true
+  param :currency, :in => ['USD', 'GBP']
 
-      def invoke
-        charge = Charge.new
-        charge.amount = param(:amount)
-        charge.currency = param(:currency)
-        charge.save
+  def invoke
+    charge = Charge.new
+    charge.amount = param(:amount)
+    charge.currency = param(:currency)
+    charge.save
 
-        ChargeResource.new(charge)
-      end
-    end
+    ChargeResource.new(charge)
+  end
+end
 
-    post '/charges', &ChargeCreateMethod
+post '/charges', &ChargeCreateMethod
+```
 
 ## Getting started with Methods
 
@@ -54,27 +58,35 @@ Methods inherit from `Poncho::Method` and override `invoke`, where they perform 
 In a similar vein to Sinatra, anything returned from `invoke` is sent right back to the user. You can
 return a http status code, a body string, or even a Rack response array.
 
-    class ChargeListMethod < Poncho::Method
-      def invoke
-        # Some DB shizzle
+```ruby
+class ChargeListMethod < Poncho::Method
+  def invoke
+    # Some DB shizzle
 
-        200
-      end
-    end
+    200
+  end
+end
+```
 
 To invoke the method just add it to your routes.
 
 Using Rails:
 
-    match '/users' => UsersListMethod, :via => :get
+```ruby
+match '/users' => UsersListMethod, :via => :get
+```
 
 Using Sinatra:
 
-    get '/users', &UsersListMethod
+```ruby
+get '/users', &UsersListMethod
+```
 
 Or invoke manually:
 
-    UsersListMethod.call(rack_env)
+```ruby
+UsersListMethod.call(rack_env)
+```
 
 If you're writing a JSON API, you'll probably want to inherit the Method from `Poncho::JSONMethod` instead of
 `Poncho::Method`, but we'll cover that later.
@@ -85,11 +97,15 @@ You can get access to the request params, via the `params` or `param(name)` meth
 
 Before you can use a param though, you need to define it:
 
-    param :param_name
+```ruby
+param :param_name
+```
 
 By default, param are of type 'string'. you can choose a different type via the `:type` option:
 
-    param :amount, :type => :integer
+```ruby
+param :amount, :type => :integer
+```
 
 There are a bunch of predefined types, such as `:integer`, `:array`, `:boolean_string` etc, but you can
 also easily define your own custom ones (covered later).
@@ -106,35 +122,45 @@ As well as the default type validation, Poncho lets you validate presence, forma
 
 For example, to validate that a `:currency` parameter is provided, pass in the `:presence' option:
 
-    param :currency, :presence => true
+```ruby
+param :currency, :presence => true
+```
 
 To validate that a currency is either 'USD' or 'GBP', use the `:in` option.
 
-    param :currency, :in => ['USD', 'GBP']
+```ruby
+param :currency, :in => ['USD', 'GBP']
+```
 
 The other supported validations out of the box are `:format`, `:not_in`, and `:length`:
 
-    param :email, :format => /@/
-    param :password, :length => 5..20
+```ruby
+param :email, :format => /@/
+param :password, :length => 5..20
+```
 
 ## Custom Validation
 
 You can use a custom validator via the `validate` method, passing in a block:
 
-    validate do
-      unless param(:customer_id) ~= /\Acus_/
-        errors.add(:customer_id, :invalid_customer)
-      end
-    end
+```ruby
+validate do
+  unless param(:customer_id) ~= /\Acus_/
+    errors.add(:customer_id, :invalid_customer)
+  end
+end
 
-    # Or
+# Or
 
-    validates :customer_id, :customer_validate
+validates :customer_id, :customer_validate
+```
 
 Alternatively, if your validation is being used in multiple places, you can wrap it up in a class and
 pass it to the `validates_with` method.
 
-    validates_with CustomValidator
+```ruby
+validates_with CustomValidator
+```
 
 For a good example of how to build validations, see the [
 existing ones](https://github.com/stripe/poncho/tree/master/lib/poncho/validations).
@@ -148,72 +174,84 @@ To define a custom parameter, simply inherit from `Poncho::Param`. For example, 
 `CardHashParam`. It needs to validate input via overriding the `validate_each` method, and convert input via
 overriding the `convert` method.
 
-      module Poncho
-        module Params
-          class CardHashParam < Param
-            def validate_each(method, attribute, value)
-              value = convert(value)
+```ruby
+module Poncho
+  module Params
+    class CardHashParam < Param
+      def validate_each(method, attribute, value)
+        value = convert(value)
 
-              unless value.is_a?(Hash) && value.keys == [:number, :exp_month, :exp_year, :cvc]
-                method.errors.add(attribute, :invalid_card_hash, options.merge(:value => value))
-              end
-            end
-
-            def convert(value)
-              value && value.symbolize_keys
-            end
-          end
+        unless value.is_a?(Hash) && value.keys == [:number, :exp_month, :exp_year, :cvc]
+          method.errors.add(attribute, :invalid_card_hash, options.merge(:value => value))
         end
       end
 
+      def convert(value)
+        value && value.symbolize_keys
+      end
+    end
+  end
+end
+```
+
 You can use custom parameters via the `:type` option.
 
-    param :card, :type => Poncho::Params::CardHashParam
+```ruby
+param :card, :type => Poncho::Params::CardHashParam
 
-    # Or the shortcut
-    param :card, :type => :card_hash
+# Or the shortcut
+param :card, :type => :card_hash
+```
 
 ## Request & Response
 
 You can gain access to the rack request via the `request` method, for example:
 
-    def invoke
-     accept = request.headers['Accept']
-     200
-    end
+```ruby
+def invoke
+ accept = request.headers['Accept']
+ 200
+end
+```
 
 The same goes for the response object:
 
-    def invoke
-      response.body = ['Fee-fi-fo-fum']
-      200
-    end
+```ruby
+def invoke
+  response.body = ['Fee-fi-fo-fum']
+  200
+end
+```
 
 There are some helper methods to set such things as the HTTP status response codes and body.
 
-    def invoke
-      status 201
-      body 'Created!'
-    end
+```ruby
+def invoke
+  status 201
+  body 'Created!'
+end
+```
 
 ## Method filters
 
 There are various filters you can apply to the request, for example:
 
-    class MyMethod < Poncho::Method
-      before_validation do
-        # Before validation
-      end
+```ruby
+class MyMethod < Poncho::Method
+  before_validation do
+    # Before validation
+  end
 
-      before do
-        # Before invoke
-        p params
-      end
+  before do
+    # Before invoke
+    p params
+  end
 
-      after do
-        # After invocation
-      end
-    end
+  after do
+    # After invocation
+  end
+end
+```
 
 ## Error responses
 
@@ -221,15 +259,17 @@ You can provide custom responses to exceptions via the `error` class method.
 
 Pass `error` a exception type or status code.
 
-    class MyMethod < Poncho::Method
-      error MyCustomClass do
-        'Sorry, something went wrong.'
-      end
+```ruby
+class MyMethod < Poncho::Method
+  error MyCustomClass do
+    'Sorry, something went wrong.'
+  end
 
-      error 403 do
-        'Not authorized.'
-      end
-    end
+  error 403 do
+    'Not authorized.'
+  end
+end
+```
 
 ## JSON APIs
 
@@ -237,13 +277,15 @@ If your API only returns JSON then Poncho has a convenient `JSONMethod` class wh
 will ensure that all response bodies are converted into JSON and that the correct content type
 header is set.
 
-    class TokenCreateMethod < Poncho::JSONMethod
-      param :number, :required => true
+```ruby
+class TokenCreateMethod < Poncho::JSONMethod
+  param :number, :required => true
 
-      def invoke
-        {:token => '123'}
-      end
-    end
+  def invoke
+    {:token => '123'}
+  end
+end
+```
 
 `JSONMethod` also ensures that there's valid JSON error responses to 404s and 500s, as well
 as returning a JSON error hash for validation errors.
@@ -257,45 +299,49 @@ Resources are wrappers around other classes, such as models, providing a view re
 
 You can specify attributes to be returned to the client using the same `param` syntax as documented above.
 
-    class Card
-      attr_reader :number
+```ruby
+class Card
+  attr_reader :number
 
-      def initialize(number)
-        @number = number
-      end
-    end
+  def initialize(number)
+    @number = number
+  end
+end
 
-    class CardResource < Poncho::Resource
-      param :number
-      param :description
+class CardResource < Poncho::Resource
+  param :number
+  param :description
 
-      def number
-        super[-4..-1]
-      end
-    end
+  def number
+    super[-4..-1]
+  end
+end
+```
 
 As you can see in the example above, you can override params and return a custom response.
 
 When the `Resource` instance is converted into JSON the appropriate params will be used and serialized.
 
-    class ChargeResource < Poncho::Resource
-      param :amount, :type => :integer
-      param :currency
-      param :card, :resource => CardResource
+```ruby
+class ChargeResource < Poncho::Resource
+  param :amount, :type => :integer
+  param :currency
+  param :card, :resource => CardResource
 
-      def currency
-        super || 'USD'
-      end
-    end
+  def currency
+    super || 'USD'
+  end
+end
 
-    class ChargeListMethod < Poncho::JSONMethod
-      def invoke
-        [
-          ChargeResource.new(Charge.new(1000, 'USD')),
-          ChargeResource.new(Charge.new(50, 'USD'))
-        ]
-      end
-    end
+class ChargeListMethod < Poncho::JSONMethod
+  def invoke
+    [
+      ChargeResource.new(Charge.new(1000, 'USD')),
+      ChargeResource.new(Charge.new(50, 'USD'))
+    ]
+  end
+end
+```
 
 If a particular param points to another resource, you can use the `:type => :resource` option as demonstrated above.
 


### PR DESCRIPTION
Writing code blocks as 

``````
```ruby
[...]
```
``````

instead of indenting them passes them trough pygments for syntax highlighting :)
