### PR TITLE
fix filter persistence and adds after* filters

### DIFF
--- a/lib/poncho/filters.rb
+++ b/lib/poncho/filters.rb
@@ -32,7 +32,7 @@ module Poncho
 
     module ClassMethods
       def filters
-        @filters ||= Hash.new {[]}
+        @filters ||= Hash.new {|h, k| h[k] = [] }
       end
 
       def add_filter(type, options = {}, &block)

--- a/lib/poncho/method.rb
+++ b/lib/poncho/method.rb
@@ -26,6 +26,14 @@ module Poncho
       add_filter(:before_validation, options, &block)
     end
 
+    def self.after(options = {}, &block)
+      add_filter(:after, options, &block)
+    end
+
+    def self.after_validation(options = {}, &block)
+      add_filter(:after_validation, options, &block)
+    end
+
     def self.errors
       @errors ||= {}
     end

--- a/test/poncho/test_method.rb
+++ b/test/poncho/test_method.rb
@@ -102,4 +102,62 @@ class TestMethod < MiniTest::Unit::TestCase
     status, headers, body = method.call(env())
     assert_equal({:some => 'stuff'}.to_json, body.body.first)
   end
+
+  def test_before_filter
+    method = Class.new(Poncho::Method) do
+      before do
+        halt 411
+      end
+
+      def invoke
+        200
+      end
+    end
+
+    status, headers, body = method.call(env())
+    assert_equal 411 , status
+  end
+
+  def test_before_validation_filter
+    method = Class.new(Poncho::Method) do
+      param :amount, :type => :integer
+
+      before_validation do
+        halt 411
+      end
+    end
+
+    status, headers, body = method.call(env())
+    assert_equal 411 , status
+  end
+
+  def test_after_validation_filter
+    method = Class.new(Poncho::Method) do
+      after_validation do
+        halt 411
+      end
+
+      def invoke
+        200
+      end
+    end
+
+    status, headers, body = method.call(env())
+    assert_equal 411 , status
+  end
+
+  def test_after_filter
+    method = Class.new(Poncho::Method) do
+      after do
+        halt 411
+      end
+
+      def invoke
+        200
+      end
+    end
+
+    status, headers, body = method.call(env())
+    assert_equal 411 , status
+  end
 end


### PR DESCRIPTION
The filters are broken in ruby 1.9.3.

Also added the missing  public method for `after``and``after_validation`` documented in the README.
