### PR TITLE
Ruby 2.4 compatibility (Fixnum => Integer)

### DIFF
--- a/lib/poncho/method.rb
+++ b/lib/poncho/method.rb
@@ -260,8 +260,8 @@ module Poncho
 
     def wrap
       res = catch(:halt) { yield }
-      res = [res] if Fixnum === res or String === res
-      if Array === res and Fixnum === res.first
+      res = [res] if Integer === res or String === res
+      if Array === res and Integer === res.first
         status(res.shift)
         body(res.pop)
         headers(*res)

--- a/lib/poncho/version.rb
+++ b/lib/poncho/version.rb
@@ -1,3 +1,3 @@
 module Poncho
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end


### PR DESCRIPTION
Ruby 2.4 deprecates Fixnum and Bignum in favor of a single Integer class. Using `Integer` avoids a deprecation warning.